### PR TITLE
Test acceleration by virtual job

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,14 +1,18 @@
 shared:
-   image: node:8
+   image: node:20
 jobs:
     simple:
         steps:
             - echo: echo test
         requires: [~commit]
+        annotations:
+            screwdriver.cd/virtualJob: true
     parallel:
         steps:
             - echo: echo test
         requires: [simple]
+        annotations:
+            screwdriver.cd/virtualJob: true
     join:
         steps:
             - echo: echo test


### PR DESCRIPTION
Speed up jobs whose execution is not related to testing by making them virtual jobs.
Remote join jobs are not made virtual jobs because the test may fail if a remote join job is made a virtual job.