### PR TITLE
Test acceleration by virtual job

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,7 +1,9 @@
 shared:
-    image: node:8
+    image: node:20
 jobs:
     external:
         steps:
             - echo: echo test
         requires: [~sd@7019:simple]
+        annotations:
+            screwdriver.cd/virtualJob: true


### PR DESCRIPTION
Speed up jobs whose execution is not related to testing by making them virtual jobs.
Remote join jobs are not made virtual jobs because the test may fail if a remote join job is made a virtual job.