### PR TITLE
Test acceleration by virtual job

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,19 +1,27 @@
 shared:
-    image: node:8
+    image: node:20
 jobs:
     main:
         steps:
             - echo: echo test
         requires: [ ~sd@5399:trigger, ~sd@7101:trigger ]
+        annotations:
+            screwdriver.cd/virtualJob: true
     parallel1:
         steps:
             - echo: echo test
         requires: [ main ]
+        annotations:
+            screwdriver.cd/virtualJob: true
     parallel2:
         steps:
             - echo: echo test
         requires: [ main ]
+        annotations:
+            screwdriver.cd/virtualJob: true
     join:
         steps:
             - echo: echo test
         requires: [parallel1, parallel2]
+        annotations:
+            screwdriver.cd/virtualJob: true


### PR DESCRIPTION
Speed up jobs whose execution is not related to testing by making them virtual jobs.
Remote join jobs are not made virtual jobs because the test may fail if a remote join job is made a virtual job.