### PR TITLE
Test acceleration by virtual job

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,15 +1,17 @@
 shared:
-    image: node:8
+    image: node:20
+    steps:
+        - echo: echo test
 jobs:
     success_A:
-        steps:
-            - print: echo "Starting success_A job"
         requires: [~commit]
+        annotations:
+            screwdriver.cd/virtualJob: true
     fail_A:
         steps:
             - fail: exit 1
         requires: []
     parallel_A:
-        steps:
-            - print: echo "Starting parallel_A job"
         requires: []
+        annotations:
+            screwdriver.cd/virtualJob: true


### PR DESCRIPTION
Speed up jobs whose execution is not related to testing by making them virtual jobs.
Remote join jobs are not made virtual jobs because the test may fail if a remote join job is made a virtual job.