### PR TITLE
fix: test of remote join acceleration by virtual job [1]

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,18 +1,17 @@
 shared:
    image: node:20
+   annotations:
+       screwdriver.cd/virtualJob: true
+
 jobs:
     simple:
         steps:
             - echo: echo test
         requires: [~commit]
-        annotations:
-            screwdriver.cd/virtualJob: true
     parallel:
         steps:
             - echo: echo test
         requires: [simple]
-        annotations:
-            screwdriver.cd/virtualJob: true
     join:
         steps:
             - echo: echo test


### PR DESCRIPTION
Remote join job could fail test if made a virtual job, but to fix this with https://github.com/screwdriver-cd/screwdriver/pull/3281, make remote join job a virtual job