### PR TITLE
fix: test of remote join acceleration by virtual job [2]

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,14 +2,12 @@ shared:
    image: node:20
    steps:
       - echo: echo test
+   annotations:
+      screwdriver.cd/virtualJob: true
 jobs:
     simple:
         requires: [~commit]
-        annotations:
-            screwdriver.cd/virtualJob: true
     parallel:
         requires: [simple]
-        annotations:
-            screwdriver.cd/virtualJob: true
     join:
         requires: [parallel, sd@5398:external]


### PR DESCRIPTION
Remote join job could fail test if made a virtual job, but to fix this with https://github.com/screwdriver-cd/screwdriver/pull/3281, make remote join job a virtual job