### PR TITLE
fix: add external meta test [2]

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,8 +2,8 @@ shared:
     image: node:20
 jobs:
     trigger:
+        parameters:
+            externalParam: "external_parameter" # Check if external trigger parameter can be referenced in downstream build
         steps:
-            - echo: echo test
+            - metaset: meta set externalMeta "external_meta" # Check if external trigger metadata can be referenced in downstream build
         requires: [ ~commit ]
-        annotations:
-            screwdriver.cd/virtualJob: true


### PR DESCRIPTION
Add a test to reference external meta in downstream builds.

- Downstream pipeline PR: https://github.com/screwdriver-cd-test/functional-trigger/pull/14