### PR TITLE
fix: Remove unnecessary slash from the API URL

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -4,7 +4,7 @@ jobs:
     main:
         steps:
             - get-upstream-job: |
-                EXTERNAL_JOB=$(curl -s -H 'accept: application/json' -H "Authorization:Bearer $SD_TOKEN" $SD_API_URL/events/$SD_EVENT_ID | jq -r '.startFrom | ltrimstr("~")')
+                EXTERNAL_JOB=$(curl -s -H 'accept: application/json' -H "Authorization:Bearer $SD_TOKEN" ${SD_API_URL}events/${SD_EVENT_ID} | jq -r '.startFrom | ltrimstr("~")')
             - metatest1: test "external_parameter" = `meta get parameters.externalParam.value --external $EXTERNAL_JOB --skip-fetch`
             - metatest2: test "external_meta" = `meta get "externalMeta" --external $EXTERNAL_JOB --skip-fetch`
         requires: [ ~sd@5399:trigger, ~sd@7101:trigger ]    


### PR DESCRIPTION
Since SD_API_URL is a value ending with a slash, remove any extra slash.